### PR TITLE
Added DEFAULT_AUTO_FIELD because of a warning about  auto-created pk in dashboard.Data

### DIFF
--- a/csvproject/settings.py
+++ b/csvproject/settings.py
@@ -83,6 +83,12 @@ DATABASES = {
 }
 
 
+
+# DEFAULT_AUTO_FIELD defined because  verification.phoneModel Auto-created primary key used 
+# when not defining a primary key type, by default 'django.db.models.AutoField'.
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+
+
 # Password validation
 # https://docs.djangoproject.com/en/3.1/ref/settings/#auth-password-validators
 


### PR DESCRIPTION
In newer Django versions (Django > 3.2) your code should have some setting like this not to warn when you have some models and they have some auto created fields.